### PR TITLE
fix: async await fixes

### DIFF
--- a/app/scripts/controllers/balanceCtrl.js
+++ b/app/scripts/controllers/balanceCtrl.js
@@ -85,7 +85,7 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
 	$scope.$watch(function() {
 		if (walletService.wallet == null) return null;
 		return walletService.wallet.getAddressString();
-	}, function() {
+	}, async function() {
 		if (walletService.wallet == null) return;
 		$scope.wallet = walletService.wallet;
         $scope.wallet.message_key = JSON.parse(localStorage.getItem('ComChainWallet')).message_key;
@@ -102,7 +102,7 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
         });
         
        
-        let status =  await jsc3l.bcRead.getAccountStatus($scope.wallet.getAddressString());
+        const status =  await jsc3l.bcRead.getAccountStatus($scope.wallet.getAddressString());
         $scope.is_locked = status==0;
 
         
@@ -127,7 +127,7 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
         
 	});
     
-	$scope.setBalance = function() {
+	$scope.setBalance = async function() {
         $scope.token.balance = await jsc3l.bcRead.getGlobalBalance($scope.currentWalletAddress);
         $scope.token.balanceEL = await jsc3l.bcRead.getNantBalance($scope.currentWalletAddress);
         $scope.token.balanceCM = await jsc3l.bcRead.getCmBalance($scope.currentWalletAddress);
@@ -217,7 +217,7 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
     }
     
     
-      $scope.loadDelegations= function(count,offset){
+      $scope.loadDelegations = async function(count,offset){
 
         $scope.noDelegation = true;
         $scope.noMoreDelegation = true;
@@ -232,7 +232,7 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
         document.getElementById("nextDeleg").style.display = 'none';
 
 
-        let list = await jsc3l.bcRead.getDelegationList($scope.wallet.getAddressString(),offset,offset+count-1 );
+        const list = await jsc3l.bcRead.getDelegationList($scope.wallet.getAddressString(),offset,offset+count-1);
         $scope.delegations = list;
         $scope.noDelegation = $scope.delegations.length==0 && offset==0;
         $scope.noMoreDelegation = !$scope.noDelegation && $scope.delegations.length<count;
@@ -296,7 +296,7 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
         });
    }  
     
-    $scope.saveNewDeleg = function(){
+    $scope.saveNewDeleg = async function(){
         if ($scope.trPass==walletService.password){
             walletService.setUsed();
           
@@ -306,7 +306,7 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
             } else if (isNaN($scope.currDelLimit)  || $scope.currDelLimit<=0){
                  document.getElementById('delStatus').innerHTML=$sce.trustAsHtml(globalFuncs.getDangerText($translate.instant("DELEG_InvalidDelegationLimit")));
             } else {
-               let res = await jsc3l.bcTransaction.setDelegation($scope.wallet, $scope.curraddress,$scope.currDelLimit);
+               const res = await jsc3l.bcTransaction.setDelegation($scope.wallet, $scope.curraddress,$scope.currDelLimit);
                if (res.isError){
                     globalFuncs.hideLoadingWaiting();
 			        document.getElementById('delStatus').innerHTML= $sce.trustAsHtml(globalFuncs.getDangerText(res.error));
@@ -394,14 +394,14 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
     
 
     
-    $scope.saveEditDeleg = function(){
+    $scope.saveEditDeleg = async function(){
         if ($scope.trPass==walletService.password){
             walletService.setUsed();
           
             if (isNaN($scope.currDelLimit)  || $scope.currDelLimit<=0){
                  document.getElementById('delEditStatus').innerHTML=$sce.trustAsHtml(globalFuncs.getDangerText($translate.instant("DELEG_InvalidDelegationLimit")));
             } else {
-                let res = await jsc3l.bcTransaction.setDelegation($scope.wallet, $scope.curraddress,$scope.currDelLimit);
+                const res = await jsc3l.bcTransaction.setDelegation($scope.wallet, $scope.curraddress,$scope.currDelLimit);
                 if (res.isError){
                     globalFuncs.hideLoadingWaiting();
 		            document.getElementById('delEditStatus').innerHTML= $sce.trustAsHtml(globalFuncs.getDangerText(res.error));
@@ -428,10 +428,10 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
     }
     
     
-     $scope.saveDeleteDeleg = function(){
+     $scope.saveDeleteDeleg = async function(){
         if ($scope.trPass==walletService.password){
             walletService.setUsed();
-            let res = await jsc3l.bcTransaction.setDelegation($scope.wallet, $scope.curraddress,-1);
+            const res = await jsc3l.bcTransaction.setDelegation($scope.wallet, $scope.curraddress,-1);
             if (res.isError){
                 globalFuncs.hideLoadingWaiting();
                 document.getElementById('delDeleteStatus').innerHTML= $sce.trustAsHtml(globalFuncs.getDangerText(res.error));
@@ -488,7 +488,7 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
     }
     
       
-    $scope.loadAllowances= function(count,offset){
+    $scope.loadAllowances= async function(count,offset){
 
          $scope.noAllowance = true;
          $scope.noMoreAllowance = true;
@@ -503,7 +503,7 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
           document.getElementById("nextAllow").style.display = 'none';
         
           
-         let list = await jsc3l.bcRead.getAllowanceList($scope.wallet.getAddressString(),offset,offset+count-1);
+         const list = await jsc3l.bcRead.getAllowanceList($scope.wallet.getAddressString(),offset,offset+count-1);
          $scope.allowances = list;
          $scope.noAllowance = $scope.allowances.length==0 && offset==0;
          $scope.noMoreAllowance = !$scope.noAllowance && $scope.allowances.length<count;
@@ -548,7 +548,7 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
     }
     
     
-    $scope.saveNewAllow = function(){
+    $scope.saveNewAllow = async function(){
       if ($scope.trPass==walletService.password){
            walletService.setUsed();
            
@@ -557,7 +557,7 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
             }  else if (isNaN($scope.currAllowAmount)  || $scope.currAllowAmount<=0){
                  document.getElementById('allowStatus').innerHTML=$sce.trustAsHtml(globalFuncs.getDangerText($translate.instant("ALLOW_InvalidAmount")));
             } else {
-                let res = await jsc3l.bcTransaction.setAllowance($scope.wallet, $scope.curraddress,$scope.currAllowAmount);
+                const res = await jsc3l.bcTransaction.setAllowance($scope.wallet, $scope.curraddress,$scope.currAllowAmount);
                 if (res.isError){
                     globalFuncs.hideLoadingWaiting();
 		            document.getElementById('allowStatus').innerHTML= $sce.trustAsHtml(globalFuncs.getDangerText(res.error));
@@ -589,14 +589,14 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
     
 
     
-    $scope.saveEditAllowance = function(){
+    $scope.saveEditAllowance = async function(){
         if ($scope.trPass==walletService.password){
             walletService.setUsed();
           
             if (isNaN($scope.currAllowAmount)  || $scope.currAllowAmount<=0){
                  document.getElementById('allowEditStatus').innerHTML=$sce.trustAsHtml(globalFuncs.getDangerText($translate.instant("ALLOW_InvalidAmount")));
             } else {
-                let res = await jsc3l.bcTransaction..setAllowance($scope.wallet, $scope.curraddress,$scope.currAllowAmount);
+                const res = await jsc3l.bcTransaction..setAllowance($scope.wallet, $scope.curraddress,$scope.currAllowAmount);
                 if (res.isError){
                     globalFuncs.hideLoadingWaiting();
 		            document.getElementById('allowEditStatus').innerHTML= $sce.trustAsHtml(globalFuncs.getDangerText(res.error));
@@ -625,10 +625,10 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
     }
     
 
-     $scope.saveDeleteAllowance = function(){
+     $scope.saveDeleteAllowance = async function(){
         if ($scope.trPass==walletService.password){
            walletService.setUsed();
-           let res = await jsc3l.bcTransaction..setAllowance($scope.wallet, $scope.curraddress,-1);
+           const res = await jsc3l.bcTransaction..setAllowance($scope.wallet, $scope.curraddress,-1);
            if (res.isError){
                 globalFuncs.hideLoadingWaiting();
 		        document.getElementById('allowDeleteStatus').innerHTML= $sce.trustAsHtml(globalFuncs.getDangerText(res.error));
@@ -811,7 +811,7 @@ var balanceCtrl = function($scope, $locale, $sce, walletService,contactservice, 
     }
     
     
-    $scope.createConsultRight = function() {
+    $scope.createConsultRight = async function() {
        if ($scope.start_date.getTime()>=$scope.end_date.getTime()) {
            document.getElementById('createStatus').innerHTML = $sce.trustAsHtml(globalFuncs.getDangerText($translate.instant("CRI_wrongDates"))); 
        } else if ($scope.trPass==walletService.password){

--- a/app/scripts/controllers/decryptWalletCtrl.js
+++ b/app/scripts/controllers/decryptWalletCtrl.js
@@ -155,8 +155,8 @@ var decryptWalletCtrl = function($scope, $sce, $translate, walletService, contac
        
     }
     
-    $scope.setAPINode = function(){
-        let success = await jsc3l.connection.testNode($scope.api);
+    $scope.setAPINode = async function(){
+        const success = await jsc3l.connection.testNode($scope.api);
         if (success){
             // store the node 
             localStorage.setItem('ComChainAPI', $scope.api);
@@ -249,7 +249,7 @@ var decryptWalletCtrl = function($scope, $sce, $translate, walletService, contac
         location.reload();
     }
     
-	$scope.decryptWallet = function() {
+	$scope.decryptWallet = async function() {
         if (document.getElementById('passwdField').value=="SetApiNode"){
             document.getElementById('passwdField').value='';
              if (document.getElementById('setApiNode')){
@@ -277,9 +277,8 @@ var decryptWalletCtrl = function($scope, $sce, $translate, walletService, contac
             walletService.wallet = $scope.wallet;
             
             
-            complete_wall = await jsc3l.ensureWalletMessageKey($scope.wallet, $translate.instant('WALL_missing_message_key'));
-            $scope.wallet = complete_wall;
-            walletService.wallet = complete_wall;
+            $scope.wallet = await jsc3l.message.ensureWalletMessageKey($scope.wallet, $translate.instant('WALL_missing_message_key'));
+            walletService.wallet = $scope.wallet;
             
             localStorage.setItem('ComChainWallet',JSON.stringify(jsc3l.wallet.encryptWallet($scope.wallet, $scope.filePassword)));
 

--- a/app/scripts/controllers/exchangeCtrl.js
+++ b/app/scripts/controllers/exchangeCtrl.js
@@ -59,13 +59,12 @@ var exchangeCtrl = function($scope, $locale, $sce, walletService, $translate) {
     };
     
     
-    $scope.setBalance = function() {
+    $scope.setBalance = async function() {
         $scope.balance = await jsc3l.bcRead.getGlobalBalance($scope.selected_account);
         $scope.balanceEL = await jsc3l.bcRead.getNantBalance($scope.selected_account);
         $scope.balanceCM = await jsc3l.bcRead.getCmBalance($scope.selected_account);
-        let acc_type_value = await jsc3l.bcRead.getAccountType($scope.selected_account);
-        $scope.acc_type_obj.setType(acc_type_value);
-        let account_status = await jsc3l.bcRead.getAccountStatus($scope.selected_account);
+        $scope.acc_type_obj.setType(await jsc3l.bcRead.getAccountType($scope.selected_account));
+        const account_status = await jsc3l.bcRead.getAccountStatus($scope.selected_account);
         if (account_status==1){
             $scope.lock_status = $translate.instant("EXC_Unlocked");
             $scope.lock_button = $translate.instant("EXC_Lock");
@@ -77,7 +76,7 @@ var exchangeCtrl = function($scope, $locale, $sce, walletService, $translate) {
         }
         $scope.limitCMm = await jsc3l.bcRead.getCmLimitBelow($scope.selected_account);
         $scope.limitCMp = await jsc3l.bcRead.getCmLimitAbove($scope.selected_account);
-        let keys = await jsc3l.message.getMessageKey($scope.selected_account, false);
+        const keys = await jsc3l.message.getMessageKey($scope.selected_account, false);
         globalFuncs.hideLoadingWaiting();
         $scope.to_message_key = keys.public_message_key;
         if ( $scope.to_message_key === undefined) {
@@ -97,11 +96,11 @@ var exchangeCtrl = function($scope, $locale, $sce, walletService, $translate) {
 		    if (walletService.wallet == null) return null;
 
 		    return walletService.wallet.getAddressString();
-	    }, function() {
+	    }, async function() {
 		    if (walletService.wallet == null) return;
 		    $scope.wallet = walletService.wallet;
-            let type = await jsc3l.bcRead.getAccountType($scope.wallet.getAddressString());
-            let status = await jsc3l.bcRead.getAccountStatus($scope.wallet.getAddressString());
+            const type = await jsc3l.bcRead.getAccountType($scope.wallet.getAddressString());
+            const status = await jsc3l.bcRead.getAccountStatus($scope.wallet.getAddressString());
             $scope.is_admin = type==2 && status==1;
       
             
@@ -112,7 +111,7 @@ var exchangeCtrl = function($scope, $locale, $sce, walletService, $translate) {
             $scope.has_nant=jsc3l.customization.hasNant();
             $scope.has_credit_mut=jsc3l.customization.hasCM();
             
-            let curr_astatus = await jsc3l.bcRead.getContractStatus();
+            const curr_astatus = await jsc3l.bcRead.getContractStatus();
             $scope.is_curr_locked = curr_astatus==0;
          
         });
@@ -198,7 +197,7 @@ var exchangeCtrl = function($scope, $locale, $sce, walletService, $translate) {
         
     }
     
-    $scope.confirmUpdate = function(){
+    $scope.confirmUpdate = async function(){
        $scope.pop_message=''; 
        // check that the CM balance is compatible with the new type
        if ($scope.pop_acc_type==1 && $scope.balanceCM<0){
@@ -230,7 +229,7 @@ var exchangeCtrl = function($scope, $locale, $sce, walletService, $translate) {
              $scope.pop_limitCMm =0;
         }
         
-        let data = await jsc3l.bcTransaction.SetAccountParam($scope.wallet, 
+        const data = await jsc3l.bcTransaction.SetAccountParam($scope.wallet, 
                                     $scope.selected_account, 
                                     status, 
                                     $scope.pop_acc_type,  
@@ -257,7 +256,7 @@ var exchangeCtrl = function($scope, $locale, $sce, walletService, $translate) {
        }
    }
       
-   $scope.confirmCreditAccount = function(){
+   $scope.confirmCreditAccount = async function(){
        
         var data= {};
 
@@ -265,7 +264,7 @@ var exchangeCtrl = function($scope, $locale, $sce, walletService, $translate) {
             data['memo_to']= jsc3l.message.cipherMessage($scope.to_message_key.substring(2), $scope.message_to);
         }
 
-        let rawTx = jsc3l.bcTransaction.PledgeAccount($scope.wallet, $scope.selected_account, $scope.credit_amount, data);
+        const rawTx = await jsc3l.bcTransaction.PledgeAccount($scope.wallet, $scope.selected_account, $scope.credit_amount, data);
 
         if (rawTx.isError){
             $scope.acc_message = $sce.trustAsHtml(globalFuncs.getDangerText(rawTx.error));

--- a/app/scripts/controllers/globalCtrl.js
+++ b/app/scripts/controllers/globalCtrl.js
@@ -27,27 +27,27 @@ var globalCtrl = function($scope, $locale, $sce, walletService, $translate) {
             $scope.refresh();
     });
     
-    $scope.refresh = function(){
+    $scope.refresh = async function(){
         $scope.validateStatus='';
-        let status = await jsc3l.bcRead.getIsOwner($scope.wallet.getAddressString());
+        const status = await jsc3l.bcRead.getIsOwner($scope.wallet.getAddressString());
         $scope.is_owner = status==1;
         $scope.owner_account=$scope.wallet.getAddressString();
         $scope.load(); 
     }
     
-    $scope.load = function(){
+    $scope.load = async function(){
         globalFuncs.showLoading($translate.instant("GP_Wait"));
 
         $scope.CUR_nanti=globalFuncs.currencies.CUR_nanti;
 
         $scope.taxes_amount = await jsc3l.bcRead.getTaxAmount($scope.wallet.getAddressString());
         $scope.taxes_amount_leg = await jsc3l.bcRead.getLegTaxAmount($scope.wallet.getAddressString());
-        let acc = await jsc3l.bcRead.getTaxAccount();
-        let tot = await jsc3l.bcRead.getTotalAmount($scope.wallet.getAddressString());
-        let curr_status = await jsc3l.bcRead.getContractStatus();
-        $scope.is_curr_locked = curr_status==0;
-        $scope.total_amount = tot/100.0;
+        const acc = await jsc3l.bcRead.getTaxAccount();
         $scope.tax_account = '0x'+acc.substring(26, 67);
+        const tot = await jsc3l.bcRead.getTotalAmount($scope.wallet.getAddressString());
+        $scope.total_amount = tot/100.0;
+        const curr_status = await jsc3l.bcRead.getContractStatus();
+        $scope.is_curr_locked = curr_status==0;
         globalFuncs.hideLoadingWaiting();         
     }
      
@@ -57,9 +57,9 @@ var globalCtrl = function($scope, $locale, $sce, walletService, $translate) {
         $scope.confTaxPop.open();
     }
     
-    $scope.confirmTax = function(){
+    $scope.confirmTax = async function(){
         $scope.confTaxPop.close();
-        let res = await jsc3l.bcTransaction.SetTaxAmount($scope.wallet, $scope.new_tax_amount);
+        const res = await jsc3l.bcTransaction.SetTaxAmount($scope.wallet, $scope.new_tax_amount);
         if (res.isError){
             $scope.validateStatus= $sce.trustAsHtml(globalFuncs.getDangerText($translate.instant("GLB_Tax_amount_not_updated")));
         } else {
@@ -74,9 +74,9 @@ var globalCtrl = function($scope, $locale, $sce, walletService, $translate) {
         $scope.confTaxLegPop.open();
     }
     
-    $scope.confirmTaxLeg = function(){
+    $scope.confirmTaxLeg = async function(){
         $scope.confTaxLegPop.close();
-        let res = await jsc3l.bcTransaction.SetTaxLegAmount($scope.wallet, $scope.new_tax_amount_leg);
+        const res = await jsc3l.bcTransaction.SetTaxLegAmount($scope.wallet, $scope.new_tax_amount_leg);
         if (res.isError){
             $scope.validateStatus= $sce.trustAsHtml(globalFuncs.getDangerText($translate.instant("GLB_Tax_amount_not_updated")));
         } else {
@@ -92,8 +92,8 @@ var globalCtrl = function($scope, $locale, $sce, walletService, $translate) {
         $scope.confTaxAccountPop.open();
     }
     
-    $scope.confirmTaxAccount = function(){
-        let res = await jsc3l.bcTransaction.SetTaxAccount($scope.wallet, $scope.new_tax_account);
+    $scope.confirmTaxAccount = async function(){
+        const res = await jsc3l.bcTransaction.SetTaxAccount($scope.wallet, $scope.new_tax_account);
         if (res.isError){
             $scope.validateStatus= $sce.trustAsHtml(globalFuncs.getDangerText($translate.instant("GLB_Tax_account_not_updated")));
         } else {
@@ -109,8 +109,8 @@ var globalCtrl = function($scope, $locale, $sce, walletService, $translate) {
     }
     
     
-    $scope.confirmStatus = function() {
-       let res = await jsc3l.bcTransaction.SetContractStatus($scope.wallet, $scope.is_curr_locked);
+    $scope.confirmStatus = async function() {
+       const res = await jsc3l.bcTransaction.SetContractStatus($scope.wallet, $scope.is_curr_locked);
        if (res.isError){
             $scope.validateStatus= $sce.trustAsHtml(globalFuncs.getDangerText($translate.instant("GLB_status_not_updated")));
        } else {
@@ -127,8 +127,8 @@ var globalCtrl = function($scope, $locale, $sce, walletService, $translate) {
         $scope.confOwnerAccountPop.open();
     }
     
-     $scope.confirmOwnerAccount = function(){
-       let res = await jsc3l.bcTransaction.SetOwnerAccount($scope.wallet, $scope.new_owner_account);
+     $scope.confirmOwnerAccount = async function(){
+       const res = await jsc3l.bcTransaction.SetOwnerAccount($scope.wallet, $scope.new_owner_account);
        if (res.isError){
             $scope.validateStatus= $sce.trustAsHtml(globalFuncs.getDangerText($translate.instant("GLB_Owner_account_not_updated")));
        } else {

--- a/app/scripts/controllers/noteCtrl.js
+++ b/app/scripts/controllers/noteCtrl.js
@@ -25,11 +25,11 @@ var noteCtrl = function($scope, $locale, $sce, walletService, $translate) {
 		    if (walletService.wallet == null) return null;
 
 		    return walletService.wallet.getAddressString();
-	    }, function() {
+	    }, async function() {
 		    if (walletService.wallet == null) return;
 		    $scope.wallet = walletService.wallet;
-            let type = await jsc3l.bcRead.getAccountType($scope.wallet.getAddressString());
-            let status = await jsc3l.bcRead.getAccountStatus($scope.wallet.getAddressString());
+            const type = await jsc3l.bcRead.getAccountType($scope.wallet.getAddressString());
+            const status = await jsc3l.bcRead.getAccountStatus($scope.wallet.getAddressString());
             $scope.is_admin = type==2 && status==1;
             
             $scope.CUR=globalFuncs.currencies.CUR;
@@ -58,9 +58,9 @@ var noteCtrl = function($scope, $locale, $sce, walletService, $translate) {
 	  }
   }
   
-  $scope.preparInfo = function(address, length){
-        let status = await jsc3l.bcRead.getAccountStatus(address);
-        let value = await jsc3l.bcRead.getNantBalance(address);
+  $scope.preparInfo = async function(address, length){
+        const status = await jsc3l.bcRead.getAccountStatus(address);
+        const value = await jsc3l.bcRead.getNantBalance(address);
         var status_txt = "NOT_Locked";
         if (status == 1){
             status_txt = "NOT_Unlocked";
@@ -112,9 +112,9 @@ var noteCtrl = function($scope, $locale, $sce, walletService, $translate) {
  
   }
   
-  $scope.lock = function(address){
+  $scope.lock = async function(address){
         $scope.curr_operation=$translate.instant("NOT_Currently")+$translate.instant("NOT_Locking") + address;
-        let data = await jsc3l.bcTransaction.SetAccountParam($scope.wallet, address, 0, 0, 0, 0);
+        const data = await jsc3l.bcTransaction.SetAccountParam($scope.wallet, address, 0, 0, 0, 0);
         if (data.isError){
             alert($translate.instant("NOT_Processing_error") + data.error);
         } else {
@@ -122,9 +122,9 @@ var noteCtrl = function($scope, $locale, $sce, walletService, $translate) {
         }
   }
   
-  $scope.adjustAmount = function(address, amount){
+  $scope.adjustAmount = async function(address, amount){
         $scope.curr_operation=$translate.instant("NOT_Currently")+$translate.instant("NOT_Pledging") +  amount + $scope.CUR + $translate.instant("NOT_to")+ address;
-        let data = await jsc3l.bcTransaction.PledgeAccount($scope.wallet, address, amount);
+        const data = await jsc3l.bcTransaction.PledgeAccount($scope.wallet, address, amount);
         if (data.isError){
            alert($translate.instant("NOT_Processing_error") + data.error);
         } else {
@@ -133,14 +133,14 @@ var noteCtrl = function($scope, $locale, $sce, walletService, $translate) {
   }
   
   // Processing coordinator
-  $scope.processInfo = function(){
+  $scope.processInfo = async function(){
       $scope.curr_operation='';
       if ($scope.curr_index == $scope.info_list.length){
            $scope.completed();
       } else {
          var address = $scope.info_list[$scope.curr_index].address;
-         let status = await jsc3l.bcRead.getAccountStatus(address);
-         let value = await    jsc3l.bcRead.getNantBalance(address);
+         const status = await jsc3l.bcRead.getAccountStatus(address);
+         const value = await jsc3l.bcRead.getNantBalance(address);
          $scope.info_list[$scope.curr_index].amount = value;
          var status_txt = "NOT_Locked";
          if (status == 1){

--- a/app/scripts/controllers/readonlytransactionsCtrl.js
+++ b/app/scripts/controllers/readonlytransactionsCtrl.js
@@ -109,7 +109,7 @@ var readonlytransactionsCtrl = function($scope, $locale, $sce, walletService,con
 	});
     
     
-    $scope.loadWatchedWallet = function() {
+    $scope.loadWatchedWallet = async function() {
         if ($scope.currentWalletAddress.toLowerCase() == $scope.watched_address.toLowerCase()) {
             $scope.show_bal=true;
             $scope.lock_date = false;
@@ -322,7 +322,7 @@ var readonlytransactionsCtrl = function($scope, $locale, $sce, walletService,con
     $scope.start_time =  0;
     $scope.end_time = 24;
     
-    $scope.addBalance = function(walletAddress,list,add_b, index){
+    $scope.addBalance = async function(walletAddress,list,add_b, index){
         if (index>=list.length){
             globalFuncs.generateTransPDF(walletAddress,
                                          list, 
@@ -355,7 +355,7 @@ var readonlytransactionsCtrl = function($scope, $locale, $sce, walletService,con
             
         } else {
             if (add_b) {
-                let value = await jsc3l.bcRead.getHistoricalGlobalBalance(walletAddress, list[index].data.block);
+                const value = await jsc3l.bcRead.getHistoricalGlobalBalance(walletAddress, list[index].data.block);
                 list[index].data.balance = value;
                 $scope.addBalance(walletAddress,list,add_b, index+1);
            

--- a/app/scripts/controllers/tabsCtrl.js
+++ b/app/scripts/controllers/tabsCtrl.js
@@ -13,7 +13,7 @@ var tabsCtrl = function($scope, $attrs, globalService, contactservice, $translat
 
     
     $scope.loaded = false;
-    let connect_ok = await jsc3l.connection.ensureComChainRepo();
+    jsc3l.connection.ensureComChainRepo().then(async function(connect_ok) {
     if (!connect_ok){
         globalFuncs.hideLoadingWaiting (true);
         $scope.ng_ok=false;
@@ -22,7 +22,7 @@ var tabsCtrl = function($scope, $attrs, globalService, contactservice, $translat
 
         $scope.$apply();
     } else{
-        let success = await jsc3l.connection.acquireEndPoint();
+        const success = await jsc3l.connection.acquireEndPoint();
         if (!$scope.loaded) {
            if (success){
                    $scope.ng_ok=true;
@@ -53,7 +53,7 @@ var tabsCtrl = function($scope, $attrs, globalService, contactservice, $translat
               $scope.$apply();
         }
     }
-
+    });
 
     
    

--- a/app/scripts/controllers/viewWalletCtrl.js
+++ b/app/scripts/controllers/viewWalletCtrl.js
@@ -38,13 +38,14 @@ var viewWalletCtrl = function($scope, walletService, contactservice, $translate)
             
         });
         
-        let status = await jsc3l.bcRead.getAccountStatus($scope.wallet.getAddressString());
+        jsc3l.bcRead.getAccountStatus($scope.wallet.getAddressString()).then(function (status) {
         $scope.is_locked = status==0;
+        });
   
         
-        let curr_status = await jsc3l.bcRead.getContractStatus();
-        $scope.is_curr_locked = curr_status==0;
- 
+        jsc3l.bcRead.getContractStatus().then(function(status) {
+        $scope.is_curr_locked = status==0;
+        });
         
         $scope.currentAddress = $scope.wallet.getAddressString();
         $scope.current_QR_content = $scope.currentAddress;
@@ -160,13 +161,13 @@ var viewWalletCtrl = function($scope, walletService, contactservice, $translate)
     }
     
     // Perform the check
-    $scope.do_check = function(){
+    $scope.do_check = async function(){
         $scope.BN_Status=globalFuncs.getWarningText($translate.instant("BN_CheckingProgress"));
-        let status= await jsc3l.bcRead.getAccountStatus($scope.bnaddress);
+        const status= await jsc3l.bcRead.getAccountStatus($scope.bnaddress);
         if (status!=0){
           $scope.BN_Status=globalFuncs.getDangerText($translate.instant("BN_NotValid"));      
         } else {
-            let valuue = await jsc3l.bcRead.getGlobalBalance($scope.bnaddress);
+            const valuue = await jsc3l.bcRead.getGlobalBalance($scope.bnaddress);
             if (globalFuncs.isValidBNValue(value)){
                $scope.BN_Status=globalFuncs.getSuccessText($translate.instant("BN_Valid")+value+globalFuncs.currencies.CUR);    
             } else {

--- a/app/scripts/directives/blockiesDrtv.js
+++ b/app/scripts/directives/blockiesDrtv.js
@@ -8,7 +8,7 @@ var blockiesDrtv = function() {
             
              var img_add =img_id==1 ? 'images/lem.png' : 'images/qrclick.png';
              
-            var the_arr = jsc3l_customization.getCssUrl().split('/');
+            var the_arr = jsc3l.customization.getCssUrl().split('/');
             the_arr.pop();
             the_arr.pop();
             if (img_id==1){

--- a/app/scripts/globalFuncs.js
+++ b/app/scripts/globalFuncs.js
@@ -161,7 +161,7 @@ var globalFuncs = function() {}
      }
      datas.push(result)
          
-     globalFuncs.generateTx(jsc3l_customization.getContract3(),
+     globalFuncs.generateTx(jsc3l.customization.getContract3(),
                             wallet, 
                             globalFuncs.setAccountsContracts, 
                             datas, 
@@ -179,7 +179,7 @@ var globalFuncs = function() {}
      }
      datas.push(result)
          
-     globalFuncs.generateTx(jsc3l_customization.getContract3(),
+     globalFuncs.generateTx(jsc3l.customization.getContract3(),
                             wallet, 
                             globalFuncs.setAccountsMemos, 
                             datas, 
@@ -188,7 +188,7 @@ var globalFuncs = function() {}
  }
  
  globalFuncs.getContactHash = function(walletAddress,callback){
-        var userInfo = ethFuncs.getDataObj(jsc3l_customization.getContract3(),  globalFuncs.contactsOf, [ethFuncs.getNakedAddress(walletAddress)]);
+        var userInfo = ethFuncs.getDataObj(jsc3l.customization.getContract3(),  globalFuncs.contactsOf, [ethFuncs.getNakedAddress(walletAddress)]);
 		ajaxReq.getEthCall(userInfo, function(data) {
             if (!data.error) {
                 var length_str = data.data.substring(66,130);
@@ -200,7 +200,7 @@ var globalFuncs = function() {}
   }
   
   globalFuncs.getMemoHash = function(walletAddress,callback){
-        var userInfo = ethFuncs.getDataObj(jsc3l_customization.getContract3(),  globalFuncs.memosOf, [ethFuncs.getNakedAddress(walletAddress)]);
+        var userInfo = ethFuncs.getDataObj(jsc3l.customization.getContract3(),  globalFuncs.memosOf, [ethFuncs.getNakedAddress(walletAddress)]);
 		ajaxReq.getEthCall(userInfo, function(data) {
             if (!data.error) {
 			    var length_str = data.data.substring(66,130);
@@ -216,7 +216,7 @@ var globalFuncs = function() {}
   /********************************************************/
   globalFuncs.storeOnIpfs = function (crypted_data,callback){
     var xhr = new XMLHttpRequest();
-    xhr.open('POST', jsc3l_customization.getEndpointAddress()+ globalFuncs.ipfsAdd, true); //
+    xhr.open('POST', jsc3l.customization.getEndpointAddress()+ globalFuncs.ipfsAdd, true); //
     xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
     xhr.onreadystatechange = function (oEvent) {  
     if (xhr.readyState === 4) {  
@@ -239,7 +239,7 @@ var globalFuncs = function() {}
   
   globalFuncs.readFromIpfs = function (hash,callback){
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', jsc3l_customization.getEndpointAddress()+ globalFuncs.ipfsCat+'?addr=' +hash, true); //
+    xhr.open('GET', jsc3l.customization.getEndpointAddress()+ globalFuncs.ipfsCat+'?addr=' +hash, true); //
     xhr.responseType = 'json';
     xhr.onreadystatechange = function (oEvent) {  
     if (xhr.readyState === 4) {  
@@ -266,7 +266,7 @@ var globalFuncs = function() {}
   
   globalFuncs.getChallenge = function (addr,callback){
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', jsc3l_customization.getEndpointAddress()+ globalFuncs.authChallenge+'?addr=' +encodeURIComponent(addr), true); //
+    xhr.open('GET', jsc3l.customization.getEndpointAddress()+ globalFuncs.authChallenge+'?addr=' +encodeURIComponent(addr), true); //
     xhr.onreadystatechange = function (oEvent) {  
     if (xhr.readyState === 4) {  
         if (xhr.status === 200) { 
@@ -287,7 +287,7 @@ var globalFuncs = function() {}
   
   globalFuncs.sendChallengeResponse = function (addr,signature,callback){
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', jsc3l_customization.getEndpointAddress()+ globalFuncs.authChallenge+'?addr=' +encodeURIComponent(addr)+'&sign='+encodeURIComponent(signature), true); //
+    xhr.open('GET', jsc3l.customization.getEndpointAddress()+ globalFuncs.authChallenge+'?addr=' +encodeURIComponent(addr)+'&sign='+encodeURIComponent(signature), true); //
     xhr.onreadystatechange = function (oEvent) {  
     if (xhr.readyState === 4) {  
         if (xhr.status === 200) { 
@@ -308,7 +308,7 @@ var globalFuncs = function() {}
   
   globalFuncs.sendLogOff = function (callback){
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', jsc3l_customization.getEndpointAddress()+ globalFuncs.authChallenge+'?addr=' +encodeURIComponent('0x0'), true); //
+    xhr.open('GET', jsc3l.customization.getEndpointAddress()+ globalFuncs.authChallenge+'?addr=' +encodeURIComponent('0x0'), true); //
     xhr.onreadystatechange = function (oEvent) {  
     if (xhr.readyState === 4) {  
         if (xhr.status === 200) { 
@@ -337,7 +337,7 @@ globalFuncs.loadWallet = function(wallet,callback){
     localStorage.removeItem("ComChainContactsInfo");
     localStorage.removeItem("ComChainMemos");
     if (!wallet.server || !wallet.server.name){
-        var new_name = jsc3l_customization.getCurencyName();
+        var new_name = jsc3l.customization.getCurencyName();
         
         if (new_name==''){    /*Fall back to avoid alreay created Monnaie-Leman account to provide the server name*/   
            new_name = "Monnaie-Leman"; 
@@ -355,11 +355,11 @@ globalFuncs.loadWallet = function(wallet,callback){
     if (server_name==''){
         callback(false);
     } else {
-        jsc3l_customization.getConfJSON(server_name,function(success){
+        jsc3l.customization.getConfJSON(server_name,function(success){
             if (success){
                 callback(success);
             } else {
-                 jsc3l_customization.getConfJSON(server_name, callback);
+                 jsc3l.customization.getConfJSON(server_name, callback);
             }
         });
         
@@ -380,7 +380,7 @@ globalFuncs.removeWallet = function(){
 /// Note checking 
 
 globalFuncs.isValidBNValue= function(value){
-    var notes = jsc3l_customization.getNoteValues();
+    var notes = jsc3l.customization.getNoteValues();
     if (notes && notes.length>0){
        for (var index in notes){
           if( Math.round(100*Number(value))== Math.round(100*Number(notes[index]))){
@@ -398,7 +398,7 @@ globalFuncs.isValidBNValue= function(value){
 
     globalFuncs.updateCss = function(){
         // replace the CSS references into the DOM
-        jsc3l_customization.updateCss();
+        jsc3l.customization.updateCss();
         globalFuncs.hideLoadingWaiting();
 
     }
@@ -406,7 +406,7 @@ globalFuncs.isValidBNValue= function(value){
     
     globalFuncs.currencies=conf_locale.server.currencies;
     globalFuncs.getCurrencies = function(){
-        globalFuncs.currencies=jsc3l_customization.getCurrencies();    
+        globalFuncs.currencies=jsc3l.customization.getCurrencies();    
     }
 
 
@@ -448,7 +448,7 @@ globalFuncs.parseAddress = function(text){
 
 globalFuncs.notify = function(title, text){
     
-    if (jsc3l_customization.isApp()){
+    if (jsc3l.customization.isApp()){
                 cordova.plugins.notification.local.schedule({
                     title: title,
                     message: text
@@ -485,7 +485,7 @@ globalFuncs.notifyApproval = function(){
    /* if (document.getElementsByClassName('trans')[0]){
             if (JSON.parse(localStorage.getItem('ComChainWallet'))){
                 var addresss = JSON.parse(localStorage.getItem('ComChainWallet')).address;
-                globalFuncs.getInfo(jsc3l_customization.getContract1(), globalFuncs.requestCount,addresss,function(count){
+                globalFuncs.getInfo(jsc3l.customization.getContract1(), globalFuncs.requestCount,addresss,function(count){
                     if (count>0){
                         document.getElementsByClassName('trans')[0].className = "trans alrt";
                     } else {
@@ -904,7 +904,7 @@ globalFuncs.generateSavePDF = function(title, key, address, callback){
             }
 
             
-           var the_arr = jsc3l_customization.getCssUrl().split('/');
+           var the_arr = jsc3l.customization.getCssUrl().split('/');
            the_arr.pop();
            the_arr.pop();
            newImg.src = the_arr.join('/')+"/images/lem.png";  
@@ -990,7 +990,7 @@ globalFuncs.generateCrPDF = function(title, on,assigned,validity,address,dest,co
             }
 
             
-            var the_arr = jsc3l_customization.getCssUrl().split('/');
+            var the_arr = jsc3l.customization.getCssUrl().split('/');
             the_arr.pop();
             the_arr.pop();
             newImg.src = the_arr.join('/')+"/images/lem.png";  
@@ -1037,7 +1037,7 @@ globalFuncs.generateSaveAdrPDF = function(walletAddress, callback){
             }
 
             
-            var the_arr = jsc3l_customization.getCssUrl().split('/');
+            var the_arr = jsc3l.customization.getCssUrl().split('/');
             the_arr.pop();
             the_arr.pop();
             newImg.src = the_arr.join('/')+"/images/ici.png";  
@@ -1131,7 +1131,7 @@ globalFuncs.generateTagsPDF = function(walletAddress, tags, callback){
             }
 
             
-            var the_arr = jsc3l_customization.getCssUrl().split('/');
+            var the_arr = jsc3l.customization.getCssUrl().split('/');
             the_arr.pop();
             the_arr.pop();
             newImg.src = the_arr.join('/')+"/images/lem.png";  
@@ -1356,7 +1356,7 @@ newImg.onload = function() {
 };
 
 
-   var the_arr = jsc3l_customization.getCssUrl().split('/');
+   var the_arr = jsc3l.customization.getCssUrl().split('/');
     the_arr.pop();
     the_arr.pop();
     newImg.src = the_arr.join('/')+"/images/etherwallet-logo.png";  
@@ -1464,7 +1464,7 @@ globalFuncs.hasConfig = function(){
      var show=false;
      if (!apiCheck){
          globalFuncs.doHide=false;
-         if (jsc3l_customization.getEndpointAddress()!=null && jsc3l_customization.getEndpointAddress() !='' ){
+         if (jsc3l.customization.getEndpointAddress()!=null && jsc3l.customization.getEndpointAddress() !='' ){
              show=true;
          }
      } else {

--- a/app/scripts/services/contactService.js
+++ b/app/scripts/services/contactService.js
@@ -127,7 +127,7 @@ var contactService = function() {
             contacts[index].name = name;
           }
       } else {
-          contacts.push( {name:name,address:address,servername:jsc3l_customization.getCurencyName()});
+          contacts.push( {name:name,address:address,servername:jsc3l.customization.getCurencyName()});
       }
       
       contacts.sort(function(a,b){return a.name.localeCompare(b.name); });


### PR DESCRIPTION
Here are corrections I've spotted to your current work. Still didn't try to compile.

To note: 
- if using `await` in the body of a function, this function should be `async`. You'll see many examples in the commit.
- Cascading callbacks are well translated to flat structure of sequential `await` instruction... But sequences of callbacks (not cascading) where actually run in parallel ... This should be kept, I chose to simply use `.then(callback)` : https://github.com/com-chain/biletujo/pull/104/commits/2861fdcdd2962f1ab3ff511435a8786e91adf2bb#diff-eb607ec6545c2c7b0b2be56c623686bce2e807f69e6714c0b1515f014cae2735R41-R48
- Prefer `const` to `let` if value isn't reassigned